### PR TITLE
Refactor use cases and create user service

### DIFF
--- a/src/http/controllers/appointments/add-to-database.ts
+++ b/src/http/controllers/appointments/add-to-database.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { FastifyReply, FastifyRequest } from "fastify";
-import { AddAppointmentToNotionUseCase } from "../../../use-cases/appointment/add-appointment-to-notion";
+import { AddAppointmentToNotionUseCase } from "../../../use-cases/appointments/add-appointment-to-notion";
 
 export const addToDatabase = async (
   req: FastifyRequest,

--- a/src/services/user-service.ts
+++ b/src/services/user-service.ts
@@ -1,0 +1,11 @@
+import { PrismaUsersRepository } from "../repositories/prisma/prisma-user";
+import { GetUserDataUseCase } from "../use-cases/user/get-user-data";
+
+export class UserService {
+  private usersRepository = new PrismaUsersRepository();
+  private getUserDataUseCase = new GetUserDataUseCase(this.usersRepository);
+
+  async getUserNotionData(userId: string) {
+    return this.getUserDataUseCase.execute(userId);
+  }
+}

--- a/src/use-cases/appointments/add-appointment-to-notion.ts
+++ b/src/use-cases/appointments/add-appointment-to-notion.ts
@@ -1,21 +1,16 @@
-import { GetUserDataUseCase } from "../user/get-user-data";
-import { PrismaUsersRepository } from "../../repositories/prisma/prisma-user";
 import { AddAppointmentItemUseCase } from "../notion/add-appointment-item-to-notion";
+import { UserService } from "../../services/user-service";
 
 export class AddAppointmentToNotionUseCase {
+  constructor(private userService: UserService = new UserService()) {}
+
   async execute({ title, userId }: { title: string; userId: string }) {
-    const userNotionData = await this.getUserNotionData(userId);
+    const userNotionData = await this.userService.getUserNotionData(userId);
 
     return this.addToAppointments({
       userNotionData,
       title,
     });
-  }
-
-  private async getUserNotionData(userId: string) {
-    const usersRepository = new PrismaUsersRepository();
-    const getUserNotionData = new GetUserDataUseCase(usersRepository);
-    return await getUserNotionData.execute(userId);
   }
 
   private async addToAppointments({

--- a/src/use-cases/books/add-book-to-notion.ts
+++ b/src/use-cases/books/add-book-to-notion.ts
@@ -1,15 +1,21 @@
 import { GoogleBooksService } from "../../lib/google-books";
 import { BookInfo } from "../../lib/google-books/types";
-import { PrismaUsersRepository } from "../../repositories/prisma/prisma-user";
 import { GetBookInfoUseCase } from "../books/get-info";
 import { AddBookItemUseCase } from "../notion/add-book-list-item-to-notion";
-import { GetUserDataUseCase } from "../user/get-user-data";
+import { UserService } from "../../services/user-service";
 
 export class AddBookToNotionUseCase {
+  constructor(
+    private userService: UserService = new UserService(),
+    private booksService: GoogleBooksService = new GoogleBooksService(
+      "AIzaSyCSD5DgEDcDEKA1zIWNw_a8VD8ag-ZUj6s"
+    )
+  ) {}
+
   async execute({ title, userId }: { title: string; userId: string }) {
     const { details } = await this.getBookInfos(title);
 
-    const userNotionData = await this.getUserNotionData(userId);
+    const userNotionData = await this.userService.getUserNotionData(userId);
 
     return await this.addToBooklist({
       bookInfos: details,
@@ -18,17 +24,8 @@ export class AddBookToNotionUseCase {
   }
 
   private async getBookInfos(title: string) {
-    const bookApiService = new GoogleBooksService(
-      "AIzaSyCSD5DgEDcDEKA1zIWNw_a8VD8ag-ZUj6s"
-    );
-    const getBookDetailsUseCase = new GetBookInfoUseCase(bookApiService);
+    const getBookDetailsUseCase = new GetBookInfoUseCase(this.booksService);
     return await getBookDetailsUseCase.execute({ title });
-  }
-
-  private async getUserNotionData(userId: string) {
-    const usersRepository = new PrismaUsersRepository();
-    const getUserNotionData = new GetUserDataUseCase(usersRepository);
-    return await getUserNotionData.execute(userId);
   }
 
   private async addToBooklist({

--- a/src/use-cases/tasks/add-task-to-notion.ts
+++ b/src/use-cases/tasks/add-task-to-notion.ts
@@ -1,21 +1,16 @@
-import { GetUserDataUseCase } from "../user/get-user-data";
-import { PrismaUsersRepository } from "../../repositories/prisma/prisma-user";
 import { AddTaskItemUseCase } from "../notion/add-task-item-to-notion";
+import { UserService } from "../../services/user-service";
 
 export class AddTaskToNotionUseCase {
+  constructor(private userService: UserService = new UserService()) {}
+
   async execute({ content, userId }: { content: string; userId: string }) {
-    const userNotionData = await this.getUserNotionData(userId);
+    const userNotionData = await this.userService.getUserNotionData(userId);
 
     return this.addToTasks({
       userNotionData,
       content,
     });
-  }
-
-  private async getUserNotionData(userId: string) {
-    const usersRepository = new PrismaUsersRepository();
-    const getUserNotionData = new GetUserDataUseCase(usersRepository);
-    return await getUserNotionData.execute(userId);
   }
 
   private async addToTasks({

--- a/src/use-cases/whatsapp/handle-webhook.ts
+++ b/src/use-cases/whatsapp/handle-webhook.ts
@@ -5,7 +5,7 @@ import { UserRepository } from "../../repositories/user";
 import { AddSerieToNotionUseCase } from "../series/add-serie-to-notion";
 import { AddMovieToNotionUseCase } from "../movies/add-movie-to-notion";
 import { AddTaskToNotionUseCase } from "../tasks/add-task-to-notion";
-import { AddAppointmentToNotionUseCase } from "../appointment/add-appointment-to-notion";
+import { AddAppointmentToNotionUseCase } from "../appointments/add-appointment-to-notion";
 import { AddBookToNotionUseCase } from "../books/add-book-to-notion";
 
 export class HandleWebhookEventUseCase {


### PR DESCRIPTION
## Summary
- add UserService to centralize notion access retrieval
- rename appointment use-case folder to appointments for consistency
- inject dependencies in media and task use cases
- fix imports after refactoring

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6863e5007fac8328bdf9ecd75b1ebecb