### PR TITLE
Add artist endpoint

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import { webhookRoutes } from "./http/controllers/webhook/routes";
 import { tasksRoutes } from "./http/controllers/tasks/routes";
 import { appointmentRoutes } from "./http/controllers/appointments/routes";
 import { booksRoutes } from "./http/controllers/books/routes";
+import { artistsRoutes } from "./http/controllers/artists/routes";
 
 export const app = fastify();
 
@@ -22,6 +23,7 @@ app.register(webhookRoutes);
 app.register(tasksRoutes);
 app.register(appointmentRoutes);
 app.register(booksRoutes);
+app.register(artistsRoutes);
 
 app.setErrorHandler((error, _, reply) => {
   if (error instanceof ZodError) {

--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -12,6 +12,8 @@ const envSchema = z.object({
   NOTION_CLIENT_ID: z.string(),
   NOTION_CLIENT_SECRET: z.string(),
   WHATSAPP_ACCESS_TOKEN: z.string(),
+  SPOTIFY_CLIENT_ID: z.string().optional(),
+  SPOTIFY_CLIENT_SECRET: z.string().optional(),
 });
 
 const _env = envSchema.safeParse(process.env);

--- a/src/http/controllers/artists/add-to-database.ts
+++ b/src/http/controllers/artists/add-to-database.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { FastifyReply, FastifyRequest } from "fastify";
+import { AddArtistToNotionUseCase } from "../../../use-cases/artists/add-artist-to-notion";
+
+export const addToDatabase = async (
+  req: FastifyRequest,
+  reply: FastifyReply
+) => {
+  const addArtistBodySchema = z.object({
+    name: z.string(),
+    userId: z.string(),
+  });
+
+  const { name, userId } = addArtistBodySchema.parse(req.body);
+
+  const addArtistToNotionUseCase = new AddArtistToNotionUseCase();
+
+  try {
+    await addArtistToNotionUseCase.execute({ name, userId });
+    reply.status(201).send({ message: `Artist ${name} added.` });
+  } catch (error: any) {
+    reply.status(400).send({ error: error.message });
+  }
+};

--- a/src/http/controllers/artists/routes.ts
+++ b/src/http/controllers/artists/routes.ts
@@ -1,0 +1,6 @@
+import { FastifyInstance } from "fastify";
+import { addToDatabase } from "./add-to-database";
+
+export const artistsRoutes = async (app: FastifyInstance) => {
+  app.post("/notion/artists/add", addToDatabase);
+};

--- a/src/lib/notion/create-artist-item-properties.ts
+++ b/src/lib/notion/create-artist-item-properties.ts
@@ -1,0 +1,20 @@
+import { CreateArtistNotion } from "./types";
+
+export const createArtistItemProperties = (data: CreateArtistNotion) => {
+  const { name, genres, followers, url } = data;
+
+  return {
+    title: {
+      title: [{ text: { content: name } }],
+    },
+    Followers: {
+      rich_text: [{ text: { content: String(followers) } }],
+    },
+    Genres: {
+      multi_select: genres.map((genre) => ({ name: genre })),
+    },
+    Url: {
+      url,
+    },
+  };
+};

--- a/src/lib/notion/index.ts
+++ b/src/lib/notion/index.ts
@@ -4,6 +4,7 @@ import { env } from "../../env";
 import {
   CreateAppointmentNotion,
   CreateBookNotion,
+  CreateArtistNotion,
   CreateTaskNotion,
   CreateWatchListItemNotion,
   GetNotionAccessToken,
@@ -13,6 +14,7 @@ import { retry } from "../../utils/retry";
 import { createTaskItemProperties } from "./create-task-item-properties";
 import { createAppointmentItemProperties } from "./create-appointment-item-properties";
 import { createBookItemProperties } from "./create-book-list-item-properties";
+import { createArtistItemProperties } from "./create-artist-item-properties";
 
 export class NotionService {
   private notion: Client;
@@ -43,6 +45,15 @@ export class NotionService {
       databaseId,
       createBookItemProperties,
       item.cover
+    );
+  }
+
+  async createArtistPage(item: CreateArtistNotion, databaseId: string) {
+    await this.createPage(
+      item,
+      databaseId,
+      createArtistItemProperties,
+      item.image
     );
   }
 

--- a/src/lib/notion/types.ts
+++ b/src/lib/notion/types.ts
@@ -1,4 +1,5 @@
 import { BookInfo } from "../google-books/types";
+import { ArtistInfo } from "../spotify/types";
 
 export interface CreateWatchListItemNotion {
   title: string;
@@ -13,6 +14,8 @@ export interface CreateWatchListItemNotion {
 }
 
 export interface CreateBookNotion extends BookInfo {}
+
+export interface CreateArtistNotion extends ArtistInfo {}
 
 export interface CreateTaskNotion {
   content: string;

--- a/src/lib/spotify/index.ts
+++ b/src/lib/spotify/index.ts
@@ -1,0 +1,58 @@
+import { env } from "../../env";
+import { ArtistInfo, ISpotifyService } from "./types";
+
+export class SpotifyService implements ISpotifyService {
+  private clientId: string;
+  private clientSecret: string;
+  private accessToken: string | null = null;
+
+  constructor(
+    clientId: string = env.SPOTIFY_CLIENT_ID ?? "",
+    clientSecret: string = env.SPOTIFY_CLIENT_SECRET ?? ""
+  ) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+  }
+
+  private async authenticate() {
+    if (this.accessToken) return;
+
+    const response = await fetch("https://accounts.spotify.com/api/token", {
+      method: "POST",
+      headers: {
+        Authorization: `Basic ${Buffer.from(`${this.clientId}:${this.clientSecret}`).toString("base64")}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: "grant_type=client_credentials",
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error("Error getting Spotify access token");
+    }
+
+    this.accessToken = data.access_token;
+  }
+
+  async getArtistInfo(name: string): Promise<{ data: ArtistInfo }> {
+    await this.authenticate();
+    const query = encodeURIComponent(name);
+    const response = await fetch(
+      `https://api.spotify.com/v1/search?q=${query}&type=artist&limit=1`,
+      { headers: { Authorization: `Bearer ${this.accessToken}` } }
+    );
+    const data = await response.json();
+    if (!response.ok || !data.artists.items.length) {
+      throw new Error("Artist not found");
+    }
+    const artist = data.artists.items[0];
+    const info: ArtistInfo = {
+      name: artist.name,
+      genres: artist.genres,
+      followers: artist.followers.total,
+      image: artist.images?.[0]?.url || "",
+      url: artist.external_urls.spotify,
+    };
+    return { data: info };
+  }
+}

--- a/src/lib/spotify/types.ts
+++ b/src/lib/spotify/types.ts
@@ -1,0 +1,11 @@
+export interface ISpotifyService {
+  getArtistInfo(name: string): Promise<{ data: ArtistInfo }>;
+}
+
+export interface ArtistInfo {
+  name: string;
+  image: string;
+  genres: string[];
+  followers: number;
+  url: string;
+}

--- a/src/use-cases/artists/add-artist-to-notion.ts
+++ b/src/use-cases/artists/add-artist-to-notion.ts
@@ -1,0 +1,42 @@
+import { SpotifyService } from "../../lib/spotify";
+import { AddArtistItemUseCase } from "../notion/add-artist-item-to-notion";
+import { UserService } from "../../services/user-service";
+import { GetArtistInfoUseCase } from "./get-artist-info";
+
+export class AddArtistToNotionUseCase {
+  constructor(
+    private userService: UserService = new UserService(),
+    private spotifyService: SpotifyService = new SpotifyService()
+  ) {}
+
+  async execute({ name, userId }: { name: string; userId: string }) {
+    const { details } = await this.getArtistInfo(name);
+
+    const userNotionData = await this.userService.getUserNotionData(userId);
+
+    return await this.addToArtistDatabase({
+      artistInfos: details,
+      userNotionData,
+    });
+  }
+
+  private async getArtistInfo(name: string) {
+    const useCase = new GetArtistInfoUseCase(this.spotifyService);
+    return await useCase.execute({ name });
+  }
+
+  private async addToArtistDatabase({
+    artistInfos,
+    userNotionData,
+  }: {
+    artistInfos: any;
+    userNotionData: any;
+  }) {
+    const addArtistItemUseCase = new AddArtistItemUseCase();
+    return await addArtistItemUseCase.execute({
+      data: artistInfos,
+      accessToken: userNotionData.accessToken,
+      databaseId: userNotionData.artistsDatabase.notion_id,
+    });
+  }
+}

--- a/src/use-cases/artists/get-artist-info.ts
+++ b/src/use-cases/artists/get-artist-info.ts
@@ -1,0 +1,19 @@
+import { SpotifyService } from "../../lib/spotify";
+import { ArtistInfo } from "../../lib/spotify/types";
+
+interface GetArtistInfoUseCaseRequest {
+  name: string;
+}
+
+interface GetArtistInfoUseCaseResponse {
+  details: ArtistInfo;
+}
+
+export class GetArtistInfoUseCase {
+  constructor(private spotifyService: SpotifyService) {}
+
+  async execute({ name }: GetArtistInfoUseCaseRequest): Promise<GetArtistInfoUseCaseResponse> {
+    const { data } = await this.spotifyService.getArtistInfo(name);
+    return { details: data };
+  }
+}

--- a/src/use-cases/notion/add-artist-item-to-notion.ts
+++ b/src/use-cases/notion/add-artist-item-to-notion.ts
@@ -1,0 +1,18 @@
+import { NotionService } from "../../lib/notion";
+import { ArtistInfo } from "../../lib/spotify/types";
+
+interface AddArtistItemUseCaseRequest {
+  data: ArtistInfo;
+  accessToken: string;
+  databaseId: string;
+}
+
+export class AddArtistItemUseCase {
+  constructor() {}
+
+  async execute({ data, accessToken, databaseId }: AddArtistItemUseCaseRequest) {
+    const notionService = new NotionService({ accessToken });
+    const response = await notionService.createArtistPage(data, databaseId);
+    return response;
+  }
+}

--- a/src/use-cases/user/get-user-data.ts
+++ b/src/use-cases/user/get-user-data.ts
@@ -21,6 +21,7 @@ export class GetUserDataUseCase {
     const contentsDatabase = userDatabases.find((db) => db.type === "contents");
     const tasksDatabase = userDatabases.find((db) => db.type === "tasks");
     const booksDatabase = userDatabases.find((db) => db.type === "books");
+    const artistsDatabase = userDatabases.find((db) => db.type === "artists");
 
     if (
       !genreDatabase ||
@@ -28,7 +29,8 @@ export class GetUserDataUseCase {
       !contentsDatabase ||
       !calendarDatabase ||
       !booksDatabase ||
-      !tasksDatabase
+      !tasksDatabase ||
+      !artistsDatabase
     ) {
       throw new Error("Databases não encontrados");
     }
@@ -40,6 +42,7 @@ export class GetUserDataUseCase {
       tasksDatabase,
       calendarDatabase,
       booksDatabase,
+      artistsDatabase,
       accessToken: user.notion_access_token,
     };
   }


### PR DESCRIPTION
## Summary
- add Spotify service for artist info
- allow spotify credentials in env
- support artist database for users
- add notion helper for artists
- expose `/notion/artists/add` endpoint

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863ec6524988328b25fee72f7bb4c24